### PR TITLE
native/Consumer: Replace panics on formatter errors with a simple fallback text

### DIFF
--- a/native/consumer/writer.go
+++ b/native/consumer/writer.go
@@ -22,7 +22,7 @@ type Writer struct {
 	Formatter formatter.Formatter
 
 	// Interceptor can be used to intercept the consumption of an event shortly
-	// before the actual consumption or directly afterwards. If nothing was
+	// before the actual consumption or directly afterward. If nothing was
 	// provided interceptor.Default will be used.
 	Interceptor interceptor.Interceptor
 
@@ -39,12 +39,12 @@ type Writer struct {
 	// additional performance costs.
 	Synchronized bool
 
-	// OnFormatError will be called if there as any kind of error while
+	// OnFormatError will be called if their as any kind of error while
 	// formatting an log.Event using the configured Formatter. If nothing was
 	// provided these errors will result in a panic.
 	OnFormatError func(*Writer, io.Writer, error)
 
-	// OnColorInitializationError will be called if there as any kind of error
+	// OnColorInitializationError will be called if their as any kind of error
 	// while initialize the color support. If nothing was provided these errors
 	// will be silently swallowed.
 	OnColorInitializationError func(*Writer, io.Writer, error)
@@ -100,7 +100,7 @@ func (instance *Writer) Consume(event log.Event, source log.CoreLogger) {
 		if v := instance.OnFormatError; v != nil {
 			v(instance, out, err)
 		} else {
-			panic(fmt.Errorf("cannot format event %v: %w", event, err))
+			content = []byte(fmt.Sprintf("LOG_EVENT_FORMAT_ERROR (event: %v, error: %v)", event, err))
 		}
 	}
 

--- a/native/consumer/writer.go
+++ b/native/consumer/writer.go
@@ -41,7 +41,7 @@ type Writer struct {
 
 	// OnFormatError will be called if their as any kind of error while
 	// formatting an log.Event using the configured Formatter. If nothing was
-	// provided these errors will result in a panic.
+	// provided these errors will result in a fallback message of the event.
 	OnFormatError func(*Writer, io.Writer, error)
 
 	// OnColorInitializationError will be called if their as any kind of error

--- a/native/consumer/writer_test.go
+++ b/native/consumer/writer_test.go
@@ -68,11 +68,9 @@ func Test_Writer_Consume_panicsOnFormatErrors(t *testing.T) {
 		})
 	})
 
-	assert.Execution(t, func() {
-		instance.Consume(givenEvent, givenLogger)
-	}).WillPanicWith("cannot format event .+?: expected")
+	instance.Consume(givenEvent, givenLogger)
 
-	assert.ToBeEqual(t, "", givenOut.String())
+	assert.ToBeMatching(t, "^LOG_EVENT_FORMAT_ERROR \\(event: .+?, error: expected\\)$", givenOut.String())
 }
 
 func Test_Writer_Consume_callsHookOnFormatErrors(t *testing.T) {


### PR DESCRIPTION
In some cases the formatters are producing errors if they have issues to format values. In those cases the consumer will panic and the whole program stops.

We believe producing a fallback message might be better than panic for a logger.