### PR TITLE
Fix link error related to Go 1.23 release

### DIFF
--- a/sdk/testlog/logger_core_compat.go
+++ b/sdk/testlog/logger_core_compat.go
@@ -1,4 +1,4 @@
-//go:build slf4gcompat
+//go:build slf4gcompat || go1.23
 
 package testlog
 

--- a/sdk/testlog/logger_core_with_depth.go
+++ b/sdk/testlog/logger_core_with_depth.go
@@ -1,4 +1,4 @@
-//go:build !slf4gcompat
+//go:build !slf4gcompat && !go1.23
 
 package testlog
 


### PR DESCRIPTION
Since release of Go 1.23 `go:linkname` is a problem and the hook into `testing.(*common).logDepth` does not longer work. Therefore (although ugly), we have to disable this feature inside of `github.com/echocat/slf4g/sdk/testlog` for now.