### PR TITLE
Improve build and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
+name: Continuous Integration
+
 on:
+  release:
+    types:
+      - published
   push:
     branches:
       - main
@@ -9,75 +14,53 @@ on:
       - synchronize
       - ready_for_review
 
-name: Continuous Integration
 jobs:
   lint:
     name: Lint
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        module: [ ., native ]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: 'stable'
           check-latest: 'true'
-
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Install dependencies
-        run: |
-          go mod download
-
-      - name: Install golangci-lint
-        run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-          golangci-lint --version
+          cache-dependency-path: |
+            ${{ matrix.module }}/go.sum
 
       - name: Lint
-        run: |
-          golangci-lint run --color=always -c .golangci.yml ./...
-
-          cd native
-          golangci-lint run --color=always -c ../.golangci.yml ./...
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+          args: "--color=always --config ${{ github.workspace }}/.golangci.yaml"
+          working-directory: ${{ matrix.module }}
 
   test:
-    name: Test
+    name: Test .
     strategy:
+      fail-fast: false
       matrix:
         go-version: [ '1.18', '1.22', '1.23', 'stable' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: 'true'
-
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Cache
-        uses: actions/cache@v4
+      - name: Install Go
+        uses: actions/setup-go@v6
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Install goveralls
-        run: go install github.com/mattn/goveralls@latest
+          go-version: '${{ matrix.go-version }}'
+          check-latest: 'true'
+          cache-dependency-path: |
+            go.sum
 
       - name: Test
         run: |
@@ -89,38 +72,32 @@ jobs:
           cp profile.cov.tmp3 profile.cov
 
       - name: Send coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          goveralls "-coverprofile=profile.cov" "-service=github" "-parallel" "-flagname=go-${{ matrix.go-version }}-${{ matrix.os }}-slf4g"
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          flag-name: go-${{ matrix.go-version }}-${{ matrix.os }}-slf4g
+          format: golang
+          file: profile.cov
 
   test-native:
     name: Test native
     strategy:
+      fail-fast: false
       matrix:
         go-version: [ '1.23', 'stable' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: 'true'
-
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Cache
-        uses: actions/cache@v4
+      - name: Install Go
+        uses: actions/setup-go@v6
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Install goveralls
-        run: go install github.com/mattn/goveralls@latest
+          go-version: '${{ matrix.go-version }}'
+          check-latest: 'true'
+          cache-dependency-path: |
+            native/go.sum
 
       - name: Test
         run: |
@@ -133,38 +110,22 @@ jobs:
           cp profile.cov.tmp3 profile.cov
 
       - name: Send coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd native
-          goveralls "-coverprofile=profile.cov" "-service=github" "-parallel" "-flagname=go-${{ matrix.go-version }}-${{ matrix.os }}-slf4g-native"
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          flag-name: go-${{ matrix.go-version }}-${{ matrix.os }}-slf4g-native
+          format: golang
+          file: native/profile.cov
 
-  # notifies that all test jobs are finished.
   finish:
+    name: Finish
     needs:
       - test
       - test-native
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 'stable'
-          check-latest: 'true'
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Install goveralls
-        run: go install github.com/mattn/goveralls@latest
-
       - name: Send coverage finish
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          goveralls "-parallel-finish" "-service=github"
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,15 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
 name: "CodeQL"
 
 on:
   push:
     branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:
     - cron: '0 18 * * 0'
@@ -22,41 +16,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language: ['go']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v5
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  create-native-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo (mit Tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag format
+        id: validate
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "tag_ok=true" >> "$GITHUB_OUTPUT"
+            echo "${TAG} is valid."
+          else
+            echo "${TAG} does not comply with required format ^v[0-9]+\\.[0-9]+\\.[0-9]+$; Skipping."
+            echo "tag_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create sub tags
+        if: steps.validate.outputs.tag_ok == 'true'
+        run: |
+          set -euo pipefail
+
+          TAG="${{ github.event.release.tag_name }}"
+          NATIVE_TAG="native/${TAG}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git rev-parse --verify --quiet "TAG" >/dev/null; then
+            COMMIT="$(git rev-list -n 1 "TAG")"
+          else
+            COMMIT="${{ github.event.release.target_commitish }}"
+          fi
+
+          echo "Set $NATIVE_TAG to $COMMIT..."
+
+          # Remove existing remote tag(s) if already exists (overwrite)
+          git push origin ":refs/tags/$NATIVE_TAG" || true
+
+          # Remove existing local tag(s) if already exists (overwrite)
+          git tag -d "$NATIVE_TAG" 2>/dev/null || true
+
+          # Create tag(s)...
+          git tag "$NATIVE_TAG" "$COMMIT"
+          
+          # Push tags(s)...
+          git push origin "refs/tags/$NATIVE_TAG"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,32 @@
+version: "2"
+
+linters:
+  exclusions:
+    paths:
+      - .idea
+      - .github
+      - var
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - misspell
+    - copyloopvar
+    - exptostd
+    - importas
+  settings:
+    misspell:
+      locale: US
+      ignore-rules:
+        - echocat
+        - slf4g
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST1003"
+        - "-ST1018"
+        - "-QF1001"
+run:
+  modules-download-mode: readonly
+  allow-parallel-runners: true
+  allow-serial-runners: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2024 echocat
+Copyright (c) 2020-2025 echocat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -147,11 +147,20 @@ Done. Enjoy!
 
 ## Implementations
 
-1. [native](native): Reference implementation of [slf4g](https://github.com/echocat/slf4g).
+1. [native](native): Reference implementation of [slf4g](https://github.com/echocat/slf4g), best use for most applications.
 
 2. [testlog](sdk/testlog): Ensure that everything which is logged within test by [slf4g](https://github.com/echocat/slf4g) appears correctly within tests.
 
-2. [recording](testing/recording): Will record everything which is logged by [slf4g](https://github.com/echocat/slf4g) and can then be asserted inside test cases.
+3. [recording](testing/recording): Will record everything which is logged by [slf4g](https://github.com/echocat/slf4g) and can then be asserted inside test cases.
+
+## Bridges
+
+There are several bridges available to use [slf4g](https://github.com/echocat/slf4g) in other frameworks:
+
+1. [sdk/bridge](sdk/bridge) to implement the [Go's SDK log interface](https://pkg.go.dev/log).
+2. [github.com/echocat/slf4g-logr](https://github.com/echocat/slf4g-logr) to implement [github.com/go-logr/logr](https://github.com/go-logr/logr).
+3. [github.com/echocat/slf4g-logrus](https://github.com/echocat/slf4g-logrus) to implement [github.com/sirupsen/logrus](https://github.com/sirupsen/logrus).
+4. [github.com/echocat/slf4g-klog](https://github.com/echocat/slf4g-klog) to implement [k8s.io/klog/v2](https://github.com/kubernetes/klog).
 
 ## Contributing
 

--- a/event_equality.go
+++ b/event_equality.go
@@ -85,16 +85,16 @@ func (instance *EventEqualityImpl) AreEventsEqual(left, right Event) (bool, erro
 		if err := left.ForEach(func(key string, lValue interface{}) error {
 			rValue, rExists := right.Get(key)
 			if !rExists {
-				return entriesNotEqualV
+				return errEntriesNotEqualV
 			}
 			if equal, err := ve.AreValuesEqual(key, lValue, rValue); err != nil {
 				return err
 			} else if !equal {
-				return entriesNotEqualV
+				return errEntriesNotEqualV
 			} else {
 				return nil
 			}
-		}); err == entriesNotEqualV {
+		}); err == errEntriesNotEqualV {
 			return false, nil
 		} else if err != nil {
 			return false, err
@@ -171,5 +171,5 @@ func (instance *ignoringKeysEventEquality) WithIgnoringKeys(keys ...string) Even
 }
 
 var (
-	entriesNotEqualV = errors.New(reflect.TypeOf((*EventEquality)(nil)).PkgPath() + "/both entries are not equal")
+	errEntriesNotEqualV = errors.New(reflect.TypeOf((*EventEquality)(nil)).PkgPath() + "/both entries are not equal")
 )

--- a/fields/equality.go
+++ b/fields/equality.go
@@ -72,15 +72,15 @@ func (instance *EqualityImpl) AreFieldsEqual(left, right Fields) (bool, error) {
 		if err := left.ForEach(func(key string, lValue interface{}) error {
 			rValue, rExists := right.Get(key)
 			if !rExists {
-				return entriesNotEqualV
+				return errEntriesNotEqualV
 			}
 			if equal, err := ve.AreValuesEqual(key, lValue, rValue); err != nil {
 				return err
 			} else if !equal {
-				return entriesNotEqualV
+				return errEntriesNotEqualV
 			}
 			return nil
-		}); err == entriesNotEqualV {
+		}); err == errEntriesNotEqualV {
 			return false, nil
 		} else if err != nil {
 			return false, err
@@ -118,5 +118,5 @@ func (instance *privateEqualityImpl) AreFieldsEqual(left, right Fields) (bool, e
 }
 
 var (
-	entriesNotEqualV = errors.New(reflect.TypeOf((*Equality)(nil)).PkgPath() + "/both entries are not equal")
+	errEntriesNotEqualV = errors.New(reflect.TypeOf((*Equality)(nil)).PkgPath() + "/both entries are not equal")
 )

--- a/fields/fields.go
+++ b/fields/fields.go
@@ -1,4 +1,4 @@
-// Fields represents a collection of key value pairs.
+// Package fields contains Fields which represents a collection of key value pairs.
 //
 // # Key and Values
 //

--- a/fields/single.go
+++ b/fields/single.go
@@ -5,7 +5,7 @@ func With(key string, value interface{}) Fields {
 	return &single{key: key, value: value}
 }
 
-// With creates an instance of Fields for the given key and a Lazy fmt.Sprintf
+// Withf creates an instance of Fields for the given key and a Lazy fmt.Sprintf
 // value from the given format and args.
 func Withf(key string, format string, args ...interface{}) Fields {
 	return With(key, LazyFormat(format, args...))

--- a/internal/support/support.go
+++ b/internal/support/support.go
@@ -1,3 +1,4 @@
+// Package support provides helper methods for internal usage.
 package support
 
 import "time"

--- a/internal/test/assert/assertions.go
+++ b/internal/test/assert/assertions.go
@@ -1,3 +1,4 @@
+// Package assert provides functions for internal test assertions.
 package assert
 
 import (
@@ -151,20 +152,20 @@ type ExecutionT struct {
 }
 
 func (instance *ExecutionT) WillPanicWith(pattern string) {
-	instance.TB.Helper()
+	instance.Helper()
 	instance.WillPanicWithRegexp(regexp.MustCompile(pattern))
 }
 
 func (instance *ExecutionT) WillPanicWithRegexp(pattern *regexp.Regexp) {
-	instance.TB.Helper()
+	instance.Helper()
 	defer func() {
-		instance.TB.Helper()
+		instance.Helper()
 		if p := recover(); p != nil {
 			if !pattern.MatchString(fmt.Sprint(p)) {
-				instance.TB.Errorf("Expected to panics with: <%v>; but got: <%+v>", pattern.String(), p)
+				instance.Errorf("Expected to panics with: <%v>; but got: <%+v>", pattern.String(), p)
 			}
 		} else {
-			instance.TB.Errorf("Expected to panics with: <%v>; but does not", pattern.String())
+			instance.Errorf("Expected to panics with: <%v>; but does not", pattern.String())
 		}
 	}()
 	instance.what()

--- a/level/level.go
+++ b/level/level.go
@@ -1,6 +1,6 @@
-// Level identifies the severity of an event to be logged. As higher ans more
-// important is the event. Trace is the less severe and Fatal the
-// most severe.
+// Package level provides Level which identifies the severity of an event to
+// be logged. As higher as more important is the event. Trace is the less
+// severe and Fatal the most severe.
 //
 // # Customization
 //
@@ -68,17 +68,17 @@ func (instance Level) CompareTo(o Level) int {
 // to order the contents of this slice by its severity.
 type Levels []Level
 
-// See sort.Interface
+// Len implements sort.Interface
 func (instance Levels) Len() int {
 	return len(instance)
 }
 
-// See sort.Interface
+// Swap implements sort.Interface
 func (instance Levels) Swap(i, j int) {
 	instance[i], instance[j] = instance[j], instance[i]
 }
 
-// See sort.Interface
+// Less implements sort.Interface
 func (instance Levels) Less(i, j int) bool {
 	return instance[i].CompareTo(instance[j]) < 0
 }

--- a/native/execution/execution.go
+++ b/native/execution/execution.go
@@ -1,3 +1,4 @@
+// Package execution contains tooling methods for simple executions.
 package execution
 
 // Execution is a simple interface for a simple execution.

--- a/native/facade/value/provider_test.go
+++ b/native/facade/value/provider_test.go
@@ -22,7 +22,7 @@ func Test_NewProvider(t *testing.T) {
 
 	assert.ToBeNotNil(t, actual)
 	assert.ToBeSame(t, givenTarget, actual.Level.Target)
-	assert.ToBeSame(t, givenTarget.ConsumerTarget.GetConsumer(), actual.Consumer.Formatter.Target)
+	assert.ToBeSame(t, givenTarget.GetConsumer(), actual.Consumer.Formatter.Target)
 }
 
 func Test_NewProvider_customize(t *testing.T) {
@@ -41,7 +41,7 @@ func Test_NewProvider_customize(t *testing.T) {
 	assert.ToBeNotNil(t, actual)
 	assert.ToBeSame(t, givenTarget, actual.Level.Target)
 	assert.ToBeSame(t, givenNames, actual.Level.Names)
-	assert.ToBeSame(t, givenTarget.ConsumerTarget.GetConsumer(), actual.Consumer.Formatter.Target)
+	assert.ToBeSame(t, givenTarget.GetConsumer(), actual.Consumer.Formatter.Target)
 }
 
 type mockProviderTarget struct {

--- a/native/formatter/encoding/doc.go
+++ b/native/formatter/encoding/doc.go
@@ -1,0 +1,2 @@
+// Package encoding contains all elements to encode to basic formats like JSON and text.
+package encoding

--- a/native/formatter/encoding/json_encoder.go
+++ b/native/formatter/encoding/json_encoder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/echocat/slf4g/native/execution"
 )
 
+// JsonEncoder encodes given elements to JSON format.
 type JsonEncoder interface {
 	TextEncoder
 

--- a/native/formatter/encoding/text_encoder.go
+++ b/native/formatter/encoding/text_encoder.go
@@ -10,6 +10,7 @@ type Buffered interface {
 	String() string
 }
 
+// TextEncoder encodes given elements to text format.
 type TextEncoder interface {
 	io.ByteWriter
 	WriteByteChecked(byte) func() error

--- a/native/formatter/formatter.go
+++ b/native/formatter/formatter.go
@@ -1,4 +1,4 @@
-// Formatter is used to format log events to a format which can logged to a
+// Package formatter is used to format log events to a format which can logged to a
 // console, file, ...
 package formatter
 

--- a/native/formatter/functions/doc.go
+++ b/native/formatter/functions/doc.go
@@ -1,0 +1,3 @@
+// Package functions provides couple help functions used while formatting
+// log messages.
+package functions

--- a/native/formatter/level.go
+++ b/native/formatter/level.go
@@ -27,7 +27,7 @@ func NewNamesBasedLevel(names level.Names) Level {
 	})
 }
 
-// NewNamesBasedLevel creates a new instance of Level which formats the given
+// NewOrdinalBasedLevel creates a new instance of Level which formats the given
 // level.Level by its ordinal.
 func NewOrdinalBasedLevel() Level {
 	return LevelFunc(func(in level.Level, using log.Provider) (interface{}, error) {
@@ -43,7 +43,7 @@ func (instance LevelFunc) FormatLevel(in level.Level, using log.Provider) (inter
 	return instance(in, using)
 }
 
-// NewFacade creates a new facade instance of Formatter using the given
+// NewLevelFacade creates a new facade instance of Formatter using the given
 // provider.
 func NewLevelFacade(provider func() Level) Level {
 	return levelFacade(provider)

--- a/native/hints/hints.go
+++ b/native/hints/hints.go
@@ -1,7 +1,7 @@
-// Hints are used while the processing of events and can adjust the behaviour
+// Package hints are used while the processing of events and can adjust the behavior
 // how stuff is processed/handled. Hints are always optional.
 package hints
 
-// Hints are used while the processing of events and can adjust the behaviour
+// Hints are used while the processing of events and can adjust the behavior
 // how stuff is processed/handled. Hints are always optional.
 type Hints interface{}

--- a/native/interceptor/interceptor.go
+++ b/native/interceptor/interceptor.go
@@ -1,6 +1,6 @@
-// Interceptors are used to intercept instances of log.Event that are requested
-// to be logged. It can modify events (before they get logged) or even fully
-// prevents to get logged.
+// Package interceptor provides Interceptors which are used to intercept instances
+// of log.Event that are requested to be logged. It can modify events (before they
+// get logged) or even fully prevents to get logged.
 package interceptor
 
 import (

--- a/native/internal/demo_flags/main.go
+++ b/native/internal/demo_flags/main.go
@@ -5,7 +5,6 @@ import (
 
 	log "github.com/echocat/slf4g"
 	"github.com/echocat/slf4g/native"
-	_ "github.com/echocat/slf4g/native"
 	"github.com/echocat/slf4g/native/facade/value"
 	_ "github.com/echocat/slf4g/sdk/bridge/hook"
 )

--- a/native/level/doc.go
+++ b/native/level/doc.go
@@ -1,3 +1,3 @@
-// Package native/level provides additions of slf4g/level for the native
+// Package level provides additions of slf4g/level for the native
 // implementations.
 package level

--- a/native/location/location.go
+++ b/native/location/location.go
@@ -1,7 +1,7 @@
-// Location defines where a log event happens. This is usually a
-// package/type/function and it's corresponding line.
+// Package location provides Location which defines where a log event happens.
+// This is usually a package/type/function, and it's corresponding line.
 package location
 
 // Location defines where a log event happens. This is usually a
-// package/type/function and it's corresponding line.
+// package/type/function, and it's corresponding line.
 type Location interface{}

--- a/sdk/bridge/hook/doc.go
+++ b/sdk/bridge/hook/doc.go
@@ -1,3 +1,6 @@
+// Package hook is an automatic hook for usage together with Go's SDK logging
+// ([log.Logger]).
+//
 // Importing this package anonymously will configure the whole application to
 // use the slf4g framework on any usage of the SDK based loggers.
 //

--- a/sdk/testlog/level/doc.go
+++ b/sdk/testlog/level/doc.go
@@ -1,0 +1,3 @@
+// Package level implements all required interfaces to comply with
+// [github.com/echocat/slf4g/level].
+package level

--- a/testing/recording/logger.go
+++ b/testing/recording/logger.go
@@ -47,7 +47,7 @@ func (instance *Logger) NewEvent(l level.Level, values map[string]interface{}) l
 	return instance.CoreLogger.NewEvent(l, values)
 }
 
-// NewEvent reimplements CoreLogger#NewEventWithFields()
+// NewEventWithFields reimplements CoreLogger#NewEventWithFields()
 func (instance *Logger) NewEventWithFields(l level.Level, f fields.ForEachEnabled) log.Event {
 	return instance.CoreLogger.NewEventWithFields(l, f)
 }

--- a/testing/recording/logger_core.go
+++ b/testing/recording/logger_core.go
@@ -29,7 +29,7 @@ const RootLoggerName = "ROOT"
 // adding in any way their context information.
 type CoreLogger struct {
 	// Provider which are managing this instance. If this value is nil
-	// log.GetProvider() will be used instead. This default behaviour could lead
+	// log.GetProvider() will be used instead. This default behavior could lead
 	// in some cases to unintended consequences.
 	Provider log.Provider
 

--- a/testing/recording/provider.go
+++ b/testing/recording/provider.go
@@ -154,7 +154,7 @@ func (instance *Provider) ResetAll() {
 	}
 }
 
-// ResetAll removes all recorded entries from the instance of root CoreLogger
+// ResetRoot removes all recorded entries from the instance of root CoreLogger
 // which is associated to this instance of Provider.
 func (instance *Provider) ResetRoot() {
 	instance.getRootLogger().Reset()


### PR DESCRIPTION
1. Autotag also `native/` if a release was created. No longer need to do so manually.
2. Streamline CI builds and bring them to latest standards.
3. Adjust to latest golangci-lint standards.
4. Update years.
5. Update documentation.